### PR TITLE
spack.yaml: Added oasis3-mct as a versioned dependency

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -5,7 +5,7 @@
 spack:
   # add package specs to the `specs` list
   specs:
-  - access-om2 ^cice5@git.2023.10.19=2023.10.19 ^mom5@git.2023.10.26=2023.10.16 ^libaccessom2@git.2023.10.26=2023.10.26 %intel@19.0.5.281
+  - access-om2 ^cice5@git.2023.10.19 ^mom5@git.2023.10.26 ^libaccessom2@git.2023.10.26 ^oasis3-mct@git.2023.11.09 %intel@19.0.5.281
   view: true
   concretizer:
     unify: true


### PR DESCRIPTION
In this PR:
* Specified version of `oasis3-mct` in ACCESS-OM2 model, thanks @harshula !
* Removed autogenerated spack tag after the `=` so it can be regenerated automatically. 