### PR TITLE
Removed reference to ACCESS-OM2 SBD

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -15,6 +15,8 @@ spack:
       require: '@4.7.4'
     netcdf-fortran:
       require: '@4.5.2'
+    nci-openmpi:
+      require: '@4.0.2'
     all:
       compiler: [intel@19.0.5.281]
   view: true

--- a/spack.yaml
+++ b/spack.yaml
@@ -5,7 +5,18 @@
 spack:
   # add package specs to the `specs` list
   specs:
-  - access-om2 ^cice5@git.2023.10.19 ^mom5@git.2023.11.09 ^libaccessom2@git.2023.10.26 ^oasis3-mct@git.2023.11.09 ^netcdf-c@4.7.4 ^netcdf-fortran@4.5.2 ^nci-openmpi@4.0.2 %intel@19.0.5.281
+  - cice5@git.2023.10.19
+  - mom5@git.2023.11.09
+  - libaccessom2@git.2023.10.26
+  packages:
+    oasis3-mct:
+      require: '@git.2023.11.09'
+    netcdf-c:
+      require: '@4.7.4'
+    netcdf-fortran:
+      require: '@4.5.2'
+    all:
+      compiler: [intel@19.0.5.281]
   view: true
   concretizer:
     unify: true


### PR DESCRIPTION
In this PR:
* Removed access-om2 spec
* Added specs for access-om2s dependencies
* Added constraints on dependency packages
﻿
