### PR TITLE
CD Fixes

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,14 +29,16 @@ jobs:
           GH_REPO: ${{ github.repository }}
         # We use the `gh` utility as it offers much easier traversal of GitHub-
         # related things (prs, issues, etc...).
+        # In this merged_branch variable, we get the list of PRs that have been merged,
+        # and sort them by when they were merged, taking the most recent (last) and
+        # returning the branch name of that PR.
         # The `cut` command splits the `pre-<version>` branch into just `<version>`,
         # which will be the new tag.
         run: |
           merged_branch=$(gh pr list \
             --state merged \
-            --limit 1 \
-            --json 'headRefName' \
-            --jq '.[].headRefName')
+            --json 'headRefName,mergedAt' \
+            --jq 'sort_by(.mergedAt) | last | .headRefName')
           echo "name=$(cut --delimiter '-' --fields 2 <<< '$merged_branch')" >> $GITHUB_OUTPUT
 
   undeploy-prereleases:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - main
+    paths:
+      - config/**
+      - spack.yaml
 
 jobs:
   generate-tag:


### PR DESCRIPTION
In this PR:
﻿* cd.yml: Only run deployments if PR changed config/spack.yaml
* cd.yml: Fixed logic for getting the branch name of the last PR merged

Modified `jq` logic for finding the lasted merged PR. I had initially said that it should `--limit 1` and I assumed (incorrectly) that the only PR it would return would be the most recently merged. It actually returned the highest PR number that had been merged!﻿