### PR TITLE
Prerelease deploy job runs on valid skipped jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
     # The conditional below asserts that we should run this job as long as the result of the dependent jobs
     # are not 'failures' or 'cancelled' (aka, either 'success' or 'skipped'). Skipped jobs may be created
     # if certain files are not updated (for example, we don't need to check the validity of json if none
-    # has been updated in the PR), so we should treat 'skipped' jobs as a vacous 'success'.
+    # has been updated in the PR), so we should treat 'skipped' jobs as a vacuous 'success'.
     # The `always()` status function is there, because (if we do not give a different status function)
     # by default there is an implicit 'if: success()' which would short-curcuit and skip the job.
     if: always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,8 @@ jobs:
       number: ${{ steps.history.outputs.commits }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
 
       - name: Get Number of Commits on ${{ github.head_ref }}
         id: history
@@ -157,6 +159,13 @@ jobs:
       - spack-yaml-checks
       - validate
       - check-versions-exist
+    # The conditional below asserts that we should run this job as long as the result of the dependent jobs
+    # are not 'failures' or 'cancelled' (aka, either 'success' or 'skipped'). Skipped jobs may be created
+    # if certain files are not updated (for example, we don't need to check the validity of json if none
+    # has been updated in the PR), so we should treat 'skipped' jobs as a vacous 'success'.
+    # The `always()` status function is there, because (if we do not give a different status function)
+    # by default there is an implicit 'if: success()' which would short-curcuit and skip the job.
+    if: always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
     uses: access-nri/build-cd/.github/workflows/deploy-1-setup.yml@main
     with:
       type: prerelease


### PR DESCRIPTION
In this PR:
* `deploy-version` job checks out HEAD ref instead of the weird merge branch by default, 
* prerelease deploy happens on skipped jobs now