### PR TITLE
'Rolling Tag' logic for pre/release builds

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -61,9 +61,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Push Tag
+        # NOTE: Regarding the config user.name/user.email, see https://github.com/actions/checkout/pull/1184
         run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
           git tag ${{ needs.generate-tag.outputs.name }} --force
           git push --tags --force
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -63,8 +63,8 @@ jobs:
       - name: Push Tag
         # NOTE: Regarding the config user.name/user.email, see https://github.com/actions/checkout/pull/1184
         run: |
-          git config user.name github-actions[bot]
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git config user.name ${{ vars.GH_ACTIONS_BOT_GIT_USER_NAME }}
+          git config user.email ${{ vars.GH_ACTIONS_BOT_GIT_USER_EMAIL }}
           git tag ${{ needs.generate-tag.outputs.name }} --force
           git push --tags --force
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -50,23 +50,10 @@ jobs:
       version-pattern: ${{ needs.generate-tag.outputs.name }}-*
     secrets: inherit
 
-  deploy-release:
-    name: Deploy Release
-    needs:
-      - generate-tag
-    uses: access-nri/build-cd/.github/workflows/deploy-1-setup.yml@main
-    with:
-      ref: ${{ github.ref_name }}
-      version: ${{ needs.generate-tag.outputs.name }}
-    secrets: inherit
-    permissions:
-      contents: write
-
   push-tag:
     name: Tag Deployment
     needs:
       - generate-tag
-      - deploy-release
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -77,5 +64,18 @@ jobs:
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git tag ${{ needs.generate-tag.outputs.name }}
-          git push --tags
+          git tag ${{ needs.generate-tag.outputs.name }} --force
+          git push --tags --force
+
+  deploy-release:
+    name: Deploy Release
+    needs:
+      - generate-tag
+      - push-tag
+    uses: access-nri/build-cd/.github/workflows/deploy-1-setup.yml@main
+    with:
+      ref: ${{ github.ref_name }}
+      version: ${{ needs.generate-tag.outputs.name }}
+    secrets: inherit
+    permissions:
+      contents: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,9 +176,10 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Push
+        # NOTE: Regarding the config user.name/user.email, see https://github.com/actions/checkout/pull/1184
         run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
           git tag ${{ needs.prerelease-deploy-version.outputs.version }} --force
           git push --tags --force
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,8 +178,8 @@ jobs:
       - name: Push
         # NOTE: Regarding the config user.name/user.email, see https://github.com/actions/checkout/pull/1184
         run: |
-          git config user.name github-actions[bot]
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git config user.name ${{ vars.GH_ACTIONS_BOT_GIT_USER_NAME }}
+          git config user.email ${{ vars.GH_ACTIONS_BOT_GIT_USER_EMAIL }}
           git tag ${{ needs.prerelease-deploy-version.outputs.version }} --force
           git push --tags --force
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,8 @@ jobs:
     needs:
       - branch-check
     outputs:
-      number: ${{ steps.get-version.outputs.number }}
+      version: ${{ steps.get-version.outputs.version-name }}
+      version-build: ${{ steps.get-version-build.outputs.version-build-name }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -148,13 +149,38 @@ jobs:
 
       - name: Generate Version Number
         id: get-version
+        # The step generates a general version number from the branch name, looking the
+        # same as a regular release build.
+        # Ex. 'pre-2024.01.1' -> '2024.01.1'
+        run: version-name=$(cut --delimiter '-' --field 2 <<< "${{ github.head_ref }}")
+
+      - name: Generate Version-Build String
+        id: get-version-build
         # This step generates the version number for prereleases, which given a branch
         # like `pre-<version>`, looks like: `<version>-<number of commits on this branch>`.
         # Ex. `pre-2024.10.1` with 2 commits on branch -> `2024.10.1-2`.
         run: |
-          number_of_commits=$(git rev-list --count origin/main..HEAD)
-          no_pre_version=$(cut --delimiter '-' --field 2 <<< "${{ github.head_ref }}")
-          echo "number=${no_pre_version}-${number_of_commits}" >> $GITHUB_OUTPUT
+          number-of-commits=$(git rev-list --count origin/main..HEAD)
+          echo "version-build-name=${{ steps.get-version.outputs.version-name }}-${number-of-commits}" >> $GITHUB_OUTPUT
+
+  update-prerelease-tag:
+    name: Update Prerelease Tag ${{ needs.prerelease-deploy-version.outputs.version }}
+    needs:
+      - prerelease-deploy-version
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Push
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git tag ${{ needs.prerelease-deploy-version.outputs.version }} --force
+          git push --tags --force
 
 
   prerelease-deploy:
@@ -178,5 +204,5 @@ jobs:
     with:
       type: prerelease
       ref: ${{ github.head_ref }}
-      version: ${{ needs.prerelease-deploy-version.outputs.number }}
+      version: ${{ needs.prerelease-deploy-version.outputs.version-build }}
     secrets: inherit


### PR DESCRIPTION
In this PR:

﻿ * cd.yml: Moved tagging logic to before deployment
 * ci.yml: Added tagging logic to before prerelease deployment

This fixes up the issue of the `spack.yaml` file (specifically, the `spack.specs` `access-om2@git.tag`) looking to clone the tag that doesn't exist (yet). We add a rolling tag for the prerelease branch so the build can progress, and then when it is merged, place the tag in it's rightful position on the `main` branch. 

This 'rolling tag' logic is noted here:

```mermaid
gitGraph
  commit tag: "2024.01.1"
  branch pre-2024.02.1
  commit tag: "2024.02.1"
```
And then when the next commit comes along:
```mermaid
gitGraph
  commit tag: "2024.01.1"
  branch pre-2024.02.1
  commit
  commit tag: "2024.02.1"
```
and then when merged:
```mermaid
gitGraph
  commit tag: "2024.01.1"
  branch pre-2024.02.1
  commit
  commit
  checkout main
  merge pre-2024.02.1 tag: "2024.02.1"
```
