### PR TITLE
Set the spack-version explicitly when @git.<gitref> is used

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2024.03.22"
+    "spack-packages": "2025.01.1"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -5,20 +5,22 @@
 spack:
   # add package specs to the `specs` list
   specs:
+    # TODO: The CI/CD doesn't support the `=access-om2` syntax yet.
+    # - access-om2@git.2024.03.0=access-om2
     - access-om2@git.2024.03.0
   packages:
     cice5:
       require:
-        - '@git.2023.10.19'
+        - '@git.2023.10.19=access-om2'
     mom5:
       require:
-        - '@git.2023.11.09'
+        - '@git.2023.11.09=access-om2'
     libaccessom2:
       require:
-        - '@git.2023.10.26'
+        - '@git.2023.10.26=access-om2'
     oasis3-mct:
       require:
-        - '@git.2023.11.09'
+        - '@git.2023.11.09=access-om2'
     netcdf-c:
       require:
         - '@4.7.4'


### PR DESCRIPTION
* Spack upstream is planning to insert a spack-version when one is not explicitly provided.
* The error we saw when using `spack config change` can be avoided when a spack-version is explicitly provided.
* This change depends on the latest spack-packages.

---
:rocket: The latest prerelease `access-om2/pr96-1` at d18ea21c29ef5ecd29f58d65b8be410077f2aa6a is here: https://github.com/ACCESS-NRI/ACCESS-OM2/pull/96#issuecomment-2629735656 :rocket:
