### PR TITLE
Prerelease to test MOM5 divide-by-zero fix

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -14,7 +14,7 @@ spack:
         - '@git.2023.10.19=access-om2'
     mom5:
       require:
-        - '@git.2023.11.09=access-om2'
+        - '@git.68ba5781d56d690669293ac7fdcc8a453fac58f0=access-om2'
     libaccessom2:
       require:
         - '@git.2023.10.26=access-om2'
@@ -52,6 +52,6 @@ spack:
         projections:
           access-om2: '{name}/2024.03.0'
           cice5: '{name}/2023.10.19-{hash:7}'
-          mom5: '{name}/2023.11.09-{hash:7}'
+          mom5: '{name}/68ba5781d56d690669293ac7fdcc8a453fac58f0-{hash:7}'
           libaccessom2: '{name}/2023.10.26-{hash:7}'
           oasis3-mct: '{name}/2023.11.09-{hash:7}'


### PR DESCRIPTION
**Do not merge**

This PR is to generate a prerelease to test a small change to MOM5 to fix a divide-by-zero error when compiled with oneAPI.

See https://github.com/ACCESS-NRI/MOM5/issues/34 and [associated PR](https://github.com/ACCESS-NRI/MOM5/pull/33).

---
:rocket: The latest prerelease `access-om2/pr100-1` at e78e6cf2283296282891d084c4c22cb31fffdba5 is here: https://github.com/ACCESS-NRI/ACCESS-OM2/pull/100#issuecomment-2712362531 :rocket:


---
:rocket: The latest prerelease `access-om2/pr100-2` at e78e6cf2283296282891d084c4c22cb31fffdba5 is here: https://github.com/ACCESS-NRI/ACCESS-OM2/pull/100#issuecomment-2712535145 :rocket:
