### PR TITLE
Set the spack-version explicitly when @git.<gitref> is used for specs

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -5,9 +5,7 @@
 spack:
   # add package specs to the `specs` list
   specs:
-    # TODO: The CI/CD doesn't support the `=access-om2` syntax yet.
-    # - access-om2@git.2024.03.0=access-om2
-    - access-om2@git.2024.03.0
+    - access-om2@git.2024.03.0=latest
   packages:
     cice5:
       require:


### PR DESCRIPTION
* Spack upstream is planning to insert a spack-version when one is not explicitly provided.
* The latest spack-packages repository contains changes that this change requires.