### PR TITLE
Add support for coupled generic-tracers

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.07.001"
+    "spack-packages": "2025.07.004"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.07.004"
+    "spack-packages": "2025.07.007"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.08.000"
+    "spack-packages": "2025.09.001"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.09.001"
+    "spack-packages": "2025.09.004"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.01.1"
+    "spack-packages": "2025.07.001"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.07.007"
+    "spack-packages": "2025.08.000"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -5,7 +5,7 @@
 spack:
   # add package specs to the `specs` list
   specs:
-    - access-om2@git.2024.03.0=latest
+    - access-om2@git.2025.09.0=latest
   packages:
     cice5:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -33,15 +33,13 @@ spack:
         - '@4.0.2'
     access-fms:
       require:
-        - '@git.mom5-2025.05.000'
+        - '@git.mom5-2025.05.000=mom5'
     access-generic-tracers:
       require:
-      # FIXME: This will need to be changed to a stable version before release.
-        - '@git.42290c1489e3e2de44be84c0b8deeb08efff0c08' # On development
-        - '+shared'
+        - '@git.2025.07.001=main'
     access-mocsy:
       require:
-        - '@git.2025.07.002'
+        - '@git.2025.07.002=gtracers'
     all:
       require:
         - '%intel@19.0.5.281'

--- a/spack.yaml
+++ b/spack.yaml
@@ -34,6 +34,7 @@ spack:
     access-fms:
       require:
         - '@git.mom5-2025.05.000=mom5'
+        - 'cppflags="-DMAXFIELDMETHODS_=600"'
     access-generic-tracers:
       require:
         - '@git.2025.07.001=main'

--- a/spack.yaml
+++ b/spack.yaml
@@ -18,7 +18,7 @@ spack:
         - '@git.2025.05.001=access-om2'
     oasis3-mct:
       require:
-        - '@git.2025.03.001=access-om2'
+        - '@git.2025.03.001'
     netcdf-c:
       require:
         - '@4.7.4'
@@ -37,7 +37,7 @@ spack:
         - 'cppflags="-DMAXFIELDMETHODS_=600"'
     access-generic-tracers:
       require:
-        - '@2025.07.002'
+        - '@2025.08.000'
     access-mocsy:
       require:
         - '@2025.07.002'

--- a/spack.yaml
+++ b/spack.yaml
@@ -12,7 +12,7 @@ spack:
         - '@git.2025.03.001=access-om2'
     mom5:
       require:
-        - '@git.2025.05.000=access-om2'
+        - '@git.2025.08.000=access-om2'
     libaccessom2:
       require:
         - '@git.2025.05.001=access-om2'
@@ -37,10 +37,10 @@ spack:
         - 'cppflags="-DMAXFIELDMETHODS_=600"'
     access-generic-tracers:
       require:
-        - '@git.2025.07.001=main'
+        - '@2025.07.002'
     access-mocsy:
       require:
-        - '@git.2025.07.002=gtracers'
+        - '@2025.07.002'
     all:
       require:
         - '%intel@19.0.5.281'

--- a/spack.yaml
+++ b/spack.yaml
@@ -37,7 +37,7 @@ spack:
         - 'cppflags="-DMAXFIELDMETHODS_=600"'
     access-generic-tracers:
       require:
-        - '@2025.08.000'
+        - '@2025.09.000'
     access-mocsy:
       require:
         - '@2025.07.002'

--- a/spack.yaml
+++ b/spack.yaml
@@ -5,7 +5,7 @@
 spack:
   # add package specs to the `specs` list
   specs:
-    - access-om2@git.2025.09.0=latest
+    - access-om2@git.2025.09.000=latest
   packages:
     cice5:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -30,7 +30,7 @@ spack:
         - '@2.6.2'
     openmpi:
       require:
-        - '@4.0.2'
+        - '@4.1.7'
     access-fms:
       require:
         - '@git.mom5-2025.05.000=mom5'

--- a/spack.yaml
+++ b/spack.yaml
@@ -21,16 +21,16 @@ spack:
         - '@git.2025.03.001'
     netcdf-c:
       require:
-        - '@4.7.4'
+        - '@4.9.2'
     netcdf-fortran:
       require:
-        - '@4.5.2'
+        - '@4.6.1'
     parallelio:
       require:
-        - '@2.5.2'
+        - '@2.6.2'
     openmpi:
       require:
-        - '@4.0.2'
+        - '@5.0.8'
     access-fms:
       require:
         - '@git.mom5-2025.05.000=mom5'

--- a/spack.yaml
+++ b/spack.yaml
@@ -30,7 +30,7 @@ spack:
         - '@2.6.2'
     openmpi:
       require:
-        - '@4.1.7'
+        - '@4.1.5'
     access-fms:
       require:
         - '@git.mom5-2025.05.000=mom5'

--- a/spack.yaml
+++ b/spack.yaml
@@ -38,6 +38,7 @@ spack:
       require:
       # FIXME: This will need to be changed to a stable version before release.
         - '@git.42290c1489e3e2de44be84c0b8deeb08efff0c08' # On development
+        - '+shared'
     access-mocsy:
       require:
         - '@git.2025.07.002'

--- a/spack.yaml
+++ b/spack.yaml
@@ -37,10 +37,10 @@ spack:
     access-generic-tracers:
       require:
       # FIXME: This will need to be changed to a stable version before release.
-        - '@git.dev-2025.06.003'
+        - '@git.42290c1489e3e2de44be84c0b8deeb08efff0c08' # On development
     access-mocsy:
       require:
-        - '@git.2025.07.001'
+        - '@git.2025.07.002'
     all:
       require:
         - '%intel@19.0.5.281'

--- a/spack.yaml
+++ b/spack.yaml
@@ -30,7 +30,7 @@ spack:
         - '@2.6.2'
     openmpi:
       require:
-        - '@5.0.8'
+        - '@4.0.2'
     access-fms:
       require:
         - '@git.mom5-2025.05.000=mom5'

--- a/spack.yaml
+++ b/spack.yaml
@@ -9,16 +9,16 @@ spack:
   packages:
     cice5:
       require:
-        - '@git.2023.10.19=access-om2'
+        - '@git.2025.03.001=access-om2'
     mom5:
       require:
-        - '@git.2023.11.09=access-om2'
+        - '@git.2025.05.000=access-om2'
     libaccessom2:
       require:
-        - '@git.2023.10.26=access-om2'
+        - '@git.2025.05.001=access-om2'
     oasis3-mct:
       require:
-        - '@git.2023.11.09=access-om2'
+        - '@git.2025.03.001=access-om2'
     netcdf-c:
       require:
         - '@4.7.4'
@@ -31,6 +31,16 @@ spack:
     openmpi:
       require:
         - '@4.0.2'
+    access-fms:
+      require:
+        - '@git.mom5-2025.05.000'
+    access-generic-tracers:
+      require:
+      # FIXME: This will need to be changed to a stable version before release.
+        - '@git.dev-2025.06.003'
+    access-mocsy:
+      require:
+        - '@git.2025.07.001'
     all:
       require:
         - '%intel@19.0.5.281'


### PR DESCRIPTION
Redo of https://github.com/ACCESS-NRI/ACCESS-OM2/pull/112 with access-om2 version 2025.09.000, rather than 2025.09.0

As before, will squash and merge upon approval

---
:rocket: The latest prerelease `access-om2/pr116-16` at 4edeb84108faf0830a30be0fadbbf907dcb8744c is here: https://github.com/ACCESS-NRI/ACCESS-OM2/pull/116#issuecomment-3325944623 :rocket:
