### PR TITLE
Infra Update `v7`: `!update-configs` Comment Command

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   cd:
     name: CD
-    uses: access-nri/build-cd/.github/workflows/cd.yml@v6
+    uses: access-nri/build-cd/.github/workflows/cd.yml@v7
     with:
       model: ${{ vars.NAME }}
       spack-manifest-schema-version: 1-0-7

--- a/.github/workflows/ci-command.yml
+++ b/.github/workflows/ci-command.yml
@@ -1,0 +1,44 @@
+name: Command
+on:
+  issue_comment:
+    types:
+      - created
+      - edited
+jobs:
+  redeploy:
+    name: Redeploy
+    if: startsWith(github.event.comment.body, '!redeploy') && github.event.issue.pull_request
+    uses: access-nri/build-cd/.github/workflows/ci.yml@v7
+    with:
+      model: ${{ vars.NAME }}
+      pr: ${{ github.event.issue.number }}
+      spack-manifest-schema-version: 1-0-7
+      config-versions-schema-version: 3-0-0
+      config-packages-schema-version: 1-0-0
+      config-version-schema-version: null
+    permissions:
+      pull-requests: write
+      contents: write
+      statuses: write
+    secrets: inherit
+  bump:
+    name: Bump
+    if: startsWith(github.event.comment.body, '!bump') && github.event.issue.pull_request
+    uses: access-nri/build-cd/.github/workflows/ci-comment.yml@v7
+    with:
+      model: ${{ vars.NAME }}
+    permissions:
+      pull-requests: write
+      contents: write
+    secrets: inherit
+  configs:
+    name: Configs
+    if: startsWith(github.event.comment.body, '!update-configs') && github.event.issue.pull_request
+    uses: access-nri/build-cd/.github/workflows/ci-comment-configs.yml@v7
+    with:
+      model: ${{ vars.NAME }}
+      auto-configs-pr-schema-version: 1-0-0
+    permissions:
+      pull-requests: write
+    secrets:
+      configs-repo-token: ${{ secrets.CONFIGS_REPO_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,11 @@ jobs:
   pr-ci:
     name: CI
     if: >-
-      (github.event_name == 'pull_request' && github.event.action != 'closed') || (github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '!redeploy'))
-    uses: access-nri/build-cd/.github/workflows/ci.yml@v6
+      github.event.action != 'closed'
+    uses: access-nri/build-cd/.github/workflows/ci.yml@v7
     with:
       model: ${{ vars.NAME }}
-      pr: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.event.issue.number }}
+      pr: ${{ github.event.pull_request.number }}
       spack-manifest-schema-version: 1-0-7
       config-versions-schema-version: 3-0-0
       config-packages-schema-version: 1-0-0
@@ -36,20 +36,10 @@ jobs:
       contents: write
       statuses: write
     secrets: inherit
-  pr-comment:
-    name: Comment
-    if: github.event_name == 'issue_comment'
-    uses: access-nri/build-cd/.github/workflows/ci-comment.yml@v6
-    with:
-      model: ${{ vars.NAME }}
-    permissions:
-      pull-requests: write
-      contents: write
-    secrets: inherit
   pr-closed:
     name: Closed
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
-    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v6
+    if: github.event.action == 'closed'
+    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v7
     with:
       root-sbd: ${{ vars.NAME }}
     secrets: inherit

--- a/config/auto-configs-pr.json
+++ b/config/auto-configs-pr.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/auto-configs-pr/1-0-0.json",
+  "profiles": {
+
+    "default": {
+      "configs_repo": "ACCESS-NRI/YOUR_CONFIG_REPO_HERE",
+      "configs": {
+        "dev-YOUR_CONFIG_HERE": {
+          "checks": {
+            "repro": true
+          }
+        }
+      },
+      "dev-YOUR_OTHER_CONFIG_HERE": {
+        "checks": {
+          "repro": false
+        }
+      }
+    }
+
+  }
+}


### PR DESCRIPTION
References issue ACCESS-NRI/build-cd#320, rollout issue ACCESS-NRI/build-cd#322, and PR ACCESS-NRI/build-cd#231

> [!IMPORTANT]
> This PR is a major update to the deployment infrastructure. See below for the prerequisites for this repository to be able to merge this PR.

## Background

It has been a bit of pain for users to have to open up model configs PRs to test out a given Prerelease build. This PR adds a feature which links Model Deployment Repositories (MDRs) to their associated Configs repositories, allowing users to update configurations with prerelease builds automatically via a `!update-configs` command. Configuration of this new command is done in a `config/auto-configs-pr.json` configuration file.

## Features

The main new features include:

* **New `!update-configs` Comment Command**: A command that can open PRs to different configuration branches in a given configs repository, based on a profile (a group of config names) - and can test reproducibility automatically. Syntax is `!update-configs [profile=PROFILE]`. Profiles are defined in the `config/auto-configs-pr.json` file, explained in [this section](#the-configauto-configs-prjson-file).

* **Reorganisation of Workflow Files**: Moved all comment command workflows into a `ci-command.yml` file.

## Prerequisites for Merging

- [x] Update `build-cd` entrypoints to `v7` (this PR!)
- [ ] Add repo-scoped `secrets.CONFIGS_REPO_TOKEN` that has `contents:write`, `pull-requests:write` for all configs repositories you are looking to open PRs into.
- [ ] Update the `config/auto-configs-pr.json` file specific to this MDR (see below for examples)

### The `config/auto-configs-pr.json` File

This file is split into multiple *profiles*. A *profile* can be thought of as a configs repository, multiple config branches to open PRs into, and what checks to run for each of those config branches. Users specify a particular *profile* through `!update-configs profile=PROFILE` (eg. `!update-configs profile=qa-only`). If no profile is specified (eg. `!update-configs`) the required `default` profile is used.

An example `config/auto-configs-pr.json` file looks like this:

```json
{
  "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/auto-configs-pr/1-0-0.json",
  "profiles": {

    "default": {
      "configs_repo": "ACCESS-NRI/access-test-configs",
      "configs": {
        "dev-01deg_jra55_iaf": {
          "checks": {
            "repro": true
          }
        }
      }
    },

    "qa-only": {
      "configs_repo": "ACCESS-NRI/access-test-configs",
      "configs": {
        "dev-01deg_jra55_iaf": {
          "checks": {
            "repro": false
          }
        },
        "dev-01deg_jra55_ryf": {
          "checks": {
            "repro": false
          }
        }
      }
    }
  }
}
```

This means that `!update-configs` invoked on a Prerelease PR for the HEAD prerelease build (for example, `access-test/pr100-2`), will automatically create one PR in `ACCESS-NRI/access-test-configs`, in a feature branch off the `dev-01deg_jra55_iaf` branch, with all changes required to use the prerelease module. Furthermore, it will run `!test repro` on that PR.

Similarly, `!update-configs profile=qa-only` will open two PRs in `ACCESS-NRI/access-test-configs`, in feature branches off the `dev-01deg_jra55_iaf` and `dev-01deg_jra55_ryf` branches respectively. Repro checks will not be run, but QA checks will run as normal.
