### PR TITLE
Prerelease to debug latest release

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -9,7 +9,7 @@ spack:
   packages:
     cice5:
       require:
-        - '@git.2025.03.001=access-om2'
+        - '@git.2023.10.19=access-om2'
     mom5:
       require:
         - '@git.2025.08.000=access-om2'
@@ -18,19 +18,19 @@ spack:
         - '@git.2025.05.001=access-om2'
     oasis3-mct:
       require:
-        - '@git.2025.03.001'
+        - '@git.2023.11.09=access-om2'
     netcdf-c:
       require:
-        - '@4.9.2'
+        - '@4.7.4'
     netcdf-fortran:
       require:
-        - '@4.6.1'
+        - '@4.5.2'
     parallelio:
       require:
-        - '@2.6.2'
+        - '@2.5.2'
     openmpi:
       require:
-        - '@4.1.5'
+        - '@4.0.2'
     access-fms:
       require:
         - '@git.mom5-2025.05.000=mom5'


### PR DESCRIPTION
We haven't officially released any configurations using the [latest release](https://github.com/ACCESS-NRI/ACCESS-OM2/releases/tag/2025.09.000) of ACCESS-OM2 using generic tracers, but an early user has reported that they are unable to run two consecutive years of the [`dev-1deg_jra55_ryf+wombatlite`](https://github.com/ACCESS-NRI/access-om2-configs/tree/042d23a0e86fc9131befcb8344b2f53b0b6dffc5) branch I set up.

The configuration crashes in the second half of the second year with:

<details>
  <summary>Error log (access-om2.err)</summary>

  ```
  --------------------------------------------------------------------------
  Primary job  terminated normally, but 1 process returned
  a non-zero exit code. Per user-direction, the job has been aborted.
  --------------------------------------------------------------------------
  forrtl: error (78): process killed (SIGTERM)
  Image              PC                Routine            Line        Source
  mom5_access_om     00000000025546C4  Unknown               Unknown  Unknown
  libpthread-2.28.s  0000150E77A1A990  Unknown               Unknown  Unknown
  libucp.so.0.0.0    0000150E71647780  ucp_worker_progre     Unknown  Unknown
  libucc_tl_ucp.so.  0000150E4C31B243  Unknown               Unknown  Unknown
  libucc_tl_ucp.so.  0000150E4C32CC92  ucc_tl_ucp_allred     Unknown  Unknown
  libucc.so.1.0.0    0000150E730C048B  Unknown               Unknown  Unknown
  libucc.so.1.0.0    0000150E730BE8DE  ucc_context_progr     Unknown  Unknown
  libmpi.so.40.30.5  0000150E7872BA05  mca_coll_ucc_allr     Unknown  Unknown
  libmpi.so.40.30.5  0000150E787950F0  PMPI_Allreduce        Unknown  Unknown
  libmpi_mpifh.so    0000150E78AE360B  Unknown               Unknown  Unknown
  mom5_access_om     00000000021DA2EB  mpp_mod_mp_mpp_su          39  mpp_sum_mpi.h
  mom5_access_om     000000000239F3E2  mpp_domains_mod_m         147  mpp_global_sum.h
  mom5_access_om     000000000070ACB1  ocean_tracer_diag        2494  ocean_tracer_diag.F90
  mom5_access_om     0000000000733B7F  ocean_tracer_diag        4438  ocean_tracer_diag.F90
  mom5_access_om     00000000006CD12A  ocean_diagnostics         159  ocean_diagnostics.F90
  mom5_access_om     0000000000451A5F  ocean_model_mod_m        1998  ocean_model.F90
  mom5_access_om     0000000000421F8C  MAIN__                    448  ocean_solo.F90
  mom5_access_om     0000000000410B62  Unknown               Unknown  Unknown
  libc-2.28.so       0000150E774677E5  __libc_start_main     Unknown  Unknown
  mom5_access_om     0000000000410A6E  Unknown               Unknown  Unknown
  ```
</details>

<details>
  <summary>PBS log (1deg_jra55_ryf.e)</summary>

  ```
  ------------------------------------------------------------------------
  Job 155422395 has exceeded memory allocation on node gadi-cpu-clx-0014.gadi.nci.org.au
  Process "orted", pid 2388174, rss 3358720, vmem 513597440
  Process "mom5_access_om", pid 2388191, rss 3999064064, vmem 5803724800
  Process "mom5_access_om", pid 2388192, rss 4003024896, vmem 5755621376
  Process "mom5_access_om", pid 2388193, rss 3999301632, vmem 5803778048
  Process "mom5_access_om", pid 2388194, rss 4004610048, vmem 5810126848
  Process "mom5_access_om", pid 2388195, rss 4006481920, vmem 5811290112
  Process "mom5_access_om", pid 2388196, rss 4006432768, vmem 5744287744
  Process "mom5_access_om", pid 2388197, rss 3999748096, vmem 5803773952
  Process "mom5_access_om", pid 2388198, rss 3999244288, vmem 5816762368
  Process "mom5_access_om", pid 2388199, rss 4017872896, vmem 5815705600
  Process "mom5_access_om", pid 2388200, rss 4022116352, vmem 5815824384
  Process "mom5_access_om", pid 2388201, rss 4011839488, vmem 5819281408
  Process "mom5_access_om", pid 2388202, rss 4006391808, vmem 5837299712
  Process "mom5_access_om", pid 2388203, rss 3436691456, vmem 5808193536
  Process "mom5_access_om", pid 2388204, rss 3437006848, vmem 5808234496
  Process "mom5_access_om", pid 2388205, rss 3445911552, vmem 5819940864
  Process "mom5_access_om", pid 2388206, rss 3443949568, vmem 5828739072
  Process "mom5_access_om", pid 2388207, rss 3436265472, vmem 5813407744
  Process "mom5_access_om", pid 2388208, rss 3436720128, vmem 5813469184
  Process "mom5_access_om", pid 2388209, rss 3437604864, vmem 5819805696
  Process "mom5_access_om", pid 2388210, rss 3436888064, vmem 5826383872
  Process "mom5_access_om", pid 2388211, rss 3445129216, vmem 5821030400
  Process "mom5_access_om", pid 2388212, rss 3444142080, vmem 5821124608
  Process "mom5_access_om", pid 2388213, rss 3437031424, vmem 5813456896
  Process "mom5_access_om", pid 2388214, rss 3437490176, vmem 5826424832
  Process "mom5_access_om", pid 2388215, rss 3789778944, vmem 5816750080
  Process "mom5_access_om", pid 2388216, rss 5777649664, vmem 7811502080
  Process "mom5_access_om", pid 2388217, rss 3780022272, vmem 5821042688
  Process "mom5_access_om", pid 2388218, rss 3784916992, vmem 5869056000
  Process "mom5_access_om", pid 2388219, rss 3782205440, vmem 5809041408
  Process "mom5_access_om", pid 2388220, rss 5694201856, vmem 7727808512
  Process "mom5_access_om", pid 2388221, rss 3791134720, vmem 5820964864
  Process "mom5_access_om", pid 2388222, rss 3787317248, vmem 5829779456
  Process "mom5_access_om", pid 2388223, rss 3776884736, vmem 5812203520
  Process "mom5_access_om", pid 2388224, rss 5690851328, vmem 7730434048
  Process "mom5_access_om", pid 2388225, rss 3783221248, vmem 5821108224
  Process "mom5_access_om", pid 2388226, rss 3782201344, vmem 5825515520
  Process "mom5_access_om", pid 2388227, rss 4143718400, vmem 5819977728
  Process "mom5_access_om", pid 2388228, rss 6128156672, vmem 7813742592
  Process "mom5_access_om", pid 2388229, rss 4134952960, vmem 5812441088
  Process "mom5_access_om", pid 2388230, rss 4135223296, vmem 5825212416
  Process "mom5_access_om", pid 2388231, rss 4142399488, vmem 5802553344
  Process "mom5_access_om", pid 2388232, rss 4142813184, vmem 5801873408
  Process "mom5_access_om", pid 2388233, rss 4142350336, vmem 5806964736
  Process "mom5_access_om", pid 2388234, rss 4142473216, vmem 5837324288
  Process "mom5_access_om", pid 2388235, rss 4132405248, vmem 5789859840
  Process "mom5_access_om", pid 2388236, rss 4134240256, vmem 5790797824
  Process "mom5_access_om", pid 2388237, rss 4142415872, vmem 5802639360
  Process "mom5_access_om", pid 2388238, rss 4141334528, vmem 5811281920
  ------------------------------------------------------------------------
  For more information visit https://opus.nci.org.au/x/SwGRAQ
  ------------------------------------------------------------------------
  Loading access-om2/2025.09.000
    Loading requirement: openmpi/4.1.5-7hthlkf oasis3-mct/2025.03.001-uiy5hq5
      libaccessom2/2025.05.001-4twfnoz cice5/2025.03.001-vhnfg6z
      mom5/2025.08.000-2ix4rqz
  MODULE ERROR DETECTED: GLOBALERR openmpi/4.1.5 cannot be loaded due to a conflict.
  (Detailed error information and backtrace has been suppressed, set $MODULES_ERROR_BACKTRACE to unsuppress.)
  
  Loading openmpi/4.1.5
    ERROR: openmpi/4.1.5 cannot be loaded due to a conflict.
      HINT: Might try "module unload openmpi" first.
  Unloading openmpi/4.1.5-7hthlkf
    ERROR: openmpi/4.1.5-7hthlkf cannot be unloaded due to a prereq.
      HINT: Might try "module unload oasis3-mct/2025.03.001-uiy5hq5
      libaccessom2/2025.05.001-4twfnoz cice5/2025.03.001-vhnfg6z
      mom5/2025.08.000-2ix4rqz" first.
  MODULE ERROR DETECTED: GLOBALERR openmpi/4.1.5 cannot be loaded due to a conflict.
  (Detailed error information and backtrace has been suppressed, set $MODULES_ERROR_BACKTRACE to unsuppress.)
  ```
</details>

The configuration runs successfully when only run 1 year at a time. Memory leak?

This PR is to generate prereleases while debugging this issue.

---
:rocket: The latest prerelease `access-om2/pr128-3` at 9bf972d299006bb000990e208fec2e3fcd0bd03a is here: https://github.com/ACCESS-NRI/ACCESS-OM2/pull/128#issuecomment-3625523875 :rocket:



