### PR TITLE
Test access-generic-tracers update: chl, light attenuation, tracer runoff fluxes

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -37,7 +37,7 @@ spack:
         - 'cppflags="-DMAXFIELDMETHODS_=600"'
     access-generic-tracers:
       require:
-        - '@git.9822bb3aeb2dec6c0e4699bd56ae4617b54d7ace=2025.09.000'  # On branch WOMBATupdate-2026-01-19
+        - '@git.a551ae636feca9f7269f36846468ccc907b84319=2025.09.000'  # On branch WOMBATupdate-2026-01-19
     access-mocsy:
       require:
         - '@2025.07.002'

--- a/spack.yaml
+++ b/spack.yaml
@@ -37,7 +37,7 @@ spack:
         - 'cppflags="-DMAXFIELDMETHODS_=600"'
     access-generic-tracers:
       require:
-        - '@2025.09.000'
+        - '@git.9822bb3aeb2dec6c0e4699bd56ae4617b54d7ace=2025.09.000'  # On branch WOMBATupdate-2026-01-19
     access-mocsy:
       require:
         - '@2025.07.002'


### PR DESCRIPTION
This PR is to generate a prerelease for testing https://github.com/ACCESS-NRI/GFDL-generic-tracers/pull/84

---
:rocket: The latest prerelease `access-om2/pr132-2` at 33a200fe1809d3011ad3f383d897397eee649bd1 is here: https://github.com/ACCESS-NRI/ACCESS-OM2/pull/132#issuecomment-3776361399 :rocket:

