### PR TITLE
Testing GCC

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "fe5c459b911f559b4af22cadcb5978f5a22af651"
+  "access-spack-packages": "02b365bade2f3d21aead5f23df7d8cd899b00f0d"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "02b365bade2f3d21aead5f23df7d8cd899b00f0d"
+  "access-spack-packages": "2026.02.003"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "2026.02.002"
+  "access-spack-packages": "2026.02.003"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "2026.02.003"
+  "access-spack-packages": "fe5c459b911f559b4af22cadcb5978f5a22af651"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -51,13 +51,13 @@ spack:
       - '@2025.07.002'
     c:
       require:
-      - 'gcc@13.2.0'
+      - 'gcc@15.1.0'
     cxx:
       require:
-      - 'gcc@13.2.0'
+      - 'gcc@15.1.0'
     fortran:
       require:
-      - 'gcc@13.2.0'
+      - 'gcc@15.1.0'
     all:
       prefer:
       - 'target=x86_64_v4'

--- a/spack.yaml
+++ b/spack.yaml
@@ -38,10 +38,10 @@ spack:
       - '@2.6.8'
     openmpi:
       require:
-      - '@5.0.8%gcc@13.2.0'
+      - '@5.0.8'
     access-fms:
       require:
-      - '@git.f9fb720d832c94f0cbd7b21ce95eda128fe80256=mom5'  # On mom5-boz-literal
+      - '@git.584974cd58fe19be09e060b219ecf6138cc1798f=mom5'  # On mom5-boz-literal
       - 'cppflags="-DMAXFIELDMETHODS_=600"'
     access-generic-tracers:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -38,7 +38,7 @@ spack:
       - '@2.6.8'
     openmpi:
       require:
-      - '@5.0.8'
+      - '@5.0.8%gcc@13.2.0'
     access-fms:
       require:
       - '@git.584974cd58fe19be09e060b219ecf6138cc1798f=mom5'  # On mom5-boz-literal

--- a/spack.yaml
+++ b/spack.yaml
@@ -41,7 +41,7 @@ spack:
       - '@5.0.8%gcc@13.2.0'
     access-fms:
       require:
-      - '@git.mom5-2025.05.000=mom5'
+      - '@git.f9fb720d832c94f0cbd7b21ce95eda128fe80256=mom5'  # On mom5-boz-literal
       - 'cppflags="-DMAXFIELDMETHODS_=600"'
     access-generic-tracers:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -18,10 +18,10 @@ spack:
       - 'io_type=PIO build_system=cmake'
     mom5:
       require:
-      - '@git.2025.08.000=access-om2'
+      - '@git.92ac46a07fcfc6bcd6995682ea6ce0fe5760ee35=access-om2'  # On branch 'gcc'
     libaccessom2:
       require:
-      - '@git.2025.05.001=access-om2'
+      - '@git.5d905fa470d6f0541dc27cfc0eca913e9bcb192d=access-om2'  # On branch 'gcc'
     oasis3-mct:
       require:
       - '@git.2025.03.001'
@@ -38,10 +38,10 @@ spack:
       - '@2.6.8'
     openmpi:
       require:
-      - '@5.0.8%gcc@13.2.0'
+      - '@5.0.8%gcc'
     access-fms:
       require:
-      - '@git.584974cd58fe19be09e060b219ecf6138cc1798f=mom5'  # On mom5-boz-literal
+      - '@git.mom5-2025.05.000=mom5'
       - 'cppflags="-DMAXFIELDMETHODS_=600"'
     access-generic-tracers:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -38,7 +38,7 @@ spack:
       - '@2.6.8'
     openmpi:
       require:
-      - '@5.0.8%gcc@13.2.0'
+      - '@5.0.8'
     access-fms:
       require:
       - '@git.mom5-2025.05.000=mom5'
@@ -50,14 +50,14 @@ spack:
       require:
       - '@2025.07.002'
     c:
-      prefer:
-      - 'gcc@15.1.0'
+      require:
+      - 'gcc@13.2.0'
     cxx:
-      prefer:
-      - 'gcc@15.1.0'
+      require:
+      - 'gcc@13.2.0'
     fortran:
-      prefer:
-      - 'gcc@15.1.0'
+      require:
+      - 'gcc@13.2.0'
     all:
       prefer:
       - 'target=x86_64_v4'

--- a/spack.yaml
+++ b/spack.yaml
@@ -38,7 +38,7 @@ spack:
       - '@2.6.8'
     openmpi:
       require:
-      - '@5.0.8'
+      - '@5.0.8%gcc@13.2.0'
     access-fms:
       require:
       - '@git.mom5-2025.05.000=mom5'
@@ -50,13 +50,13 @@ spack:
       require:
       - '@2025.07.002'
     c:
-      require:
+      prefer:
       - 'gcc@15.1.0'
     cxx:
-      require:
+      prefer:
       - 'gcc@15.1.0'
     fortran:
-      require:
+      prefer:
       - 'gcc@15.1.0'
     all:
       prefer:

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@ spack:
   definitions:
   # _name and _version are reserved definitions that inform deployments
   - _name: [access-om2]
-  - _version: [2025.12.000]
+  - _version: [2026.02.000]
   # add package specs to the `specs` list
   specs:
   - access-om2

--- a/spack.yaml
+++ b/spack.yaml
@@ -51,13 +51,13 @@ spack:
       - '@2025.07.002'
     c:
       require:
-      - 'intel-oneapi-compilers@2025.2.0'
+      - 'gcc@15.1.0'
     cxx:
       require:
-      - 'intel-oneapi-compilers@2025.2.0'
+      - 'gcc@15.1.0'
     fortran:
       require:
-      - 'intel-oneapi-compilers@2025.2.0'
+      - 'gcc@15.1.0'
     all:
       prefer:
       - 'target=x86_64_v4'

--- a/spack.yaml
+++ b/spack.yaml
@@ -45,7 +45,7 @@ spack:
       - 'cppflags="-DMAXFIELDMETHODS_=600"'
     access-generic-tracers:
       require:
-      - '@2025.09.000'
+      - '@2026.01.000'
     access-mocsy:
       require:
       - '@2025.07.002'

--- a/spack.yaml
+++ b/spack.yaml
@@ -14,7 +14,8 @@ spack:
     # Direct dependencies
     cice5:
       require:
-      - '@git.2025.03.001=access-om2'
+      - '@2026.01.000'
+      - 'io_type=PIO build_system=cmake'
     mom5:
       require:
       - '@git.2025.08.000=access-om2'
@@ -34,7 +35,7 @@ spack:
       - '@4.6.1'
     parallelio:
       require:
-      - '@2.6.2'
+      - '@2.6.8'
     openmpi:
       require:
       - '@5.0.8'


### PR DESCRIPTION
There's been some discussion on Zulip about using consistent `fdefault` fp GNU compiler flags for all model components.

The original question from @harshula was:

> For GCC compilers, should we standardise on `-fdefault-real-8` `-fdefault-double-8` or `-fdefault-real-8` for the ACCESS-OM2 components? I should update oasis3-mct and potentially libaccessom2.
> 
> cice5: https://github.com/ACCESS-NRI/cice5/blob/cf5df9d4d26265dc5c79e558e5a67834b51fd38d/CMakeLists.txt#L96
> 
> mom5: https://github.com/ACCESS-NRI/MOM5/blob/627a321f7490afc69b4a8e777992bcfb1f58b5ae/cmake/CMakeLists.txt#L62

This PR is for testing these options.

---
:rocket: The latest prerelease `access-om2/pr136-11` at d15826b3a2cb13289806df091e2470048e218dd9 is here: https://github.com/ACCESS-NRI/ACCESS-OM2/pull/136#issuecomment-3955201955 :rocket:










