### PR TITLE
Test replacing/removing -xCORE-AVX2

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "2026.02.003"
+  "access-spack-packages": "dbff638add68e70d48683d06b3bb3ae6ad0a7f38"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "dbff638add68e70d48683d06b3bb3ae6ad0a7f38"
+  "access-spack-packages": "900bb5e689803a4bfa7302500afb395b8e53beaa"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -14,14 +14,14 @@ spack:
     # Direct dependencies
     cice5:
       require:
-      - '@2026.01.000'
+      - '@git.b7b6cff7f60339d8d2fe07cc78d648bb2a9c5b67=2026.01.000'  # On branch 'mavx2'
       - 'io_type=PIO build_system=cmake'
     mom5:
       require:
-      - '@git.2025.08.000=access-om2'
+      - '@git.fd4e09d8bf26da98cf011624890e136c6e23b705=access-om2'  # On branch 'dkhutch-nesi'
     libaccessom2:
       require:
-      - '@git.2025.05.001=access-om2'
+      - '@git.afd7abf4a00e29853f6ecf3134f172b11fad62d5=access-om2'  # On branch 'dkhutch-nesi'
     oasis3-mct:
       require:
       - '@git.2025.03.001'
@@ -41,14 +41,14 @@ spack:
       - '@5.0.8'
     access-fms:
       require:
-      - '@git.mom5-2025.05.000=mom5'
+      - '@git.28f5cbadc41b823b882d3e411304f2e00265f14a=mom5'  # On branch 'dkhutch-nesi'
       - 'cppflags="-DMAXFIELDMETHODS_=600"'
     access-generic-tracers:
       require:
-      - '@2026.01.000'
+      - '@git.92a87ad44398809365591832f9a64811bf3c4a57=2026.01.000'  # On branch 'dkhutch-nesi'
     access-mocsy:
       require:
-      - '@2025.07.002'
+      - '@git.d4475dea14e9f6cf795f59f3f0cd200111ed8d0f=2025.07.002'  # On branch 'dkhutch-nesi'
     c:
       require:
       - 'intel-oneapi-compilers@2025.2.0'

--- a/spack.yaml
+++ b/spack.yaml
@@ -60,7 +60,7 @@ spack:
       - 'intel-oneapi-compilers@2025.2.0'
     all:
       prefer:
-      - 'target=x86_64_v4'
+      - 'target=cascadelake'
   view: true
   concretizer:
     unify: true

--- a/spack.yaml
+++ b/spack.yaml
@@ -60,7 +60,7 @@ spack:
       - 'intel-oneapi-compilers@2025.2.0'
     all:
       require:
-      - 'target=x86_64'
+      - 'target=haswell'
   view: true
   concretizer:
     unify: true

--- a/spack.yaml
+++ b/spack.yaml
@@ -14,14 +14,14 @@ spack:
     # Direct dependencies
     cice5:
       require:
-      - '@git.b7b6cff7f60339d8d2fe07cc78d648bb2a9c5b67=2026.01.000'  # On branch 'mavx2'
+      - '@git.5c2159bcfe13b8c597ddf049a80370c1fc8395cd=2026.01.000'  # On branch 'mavx2'
       - 'io_type=PIO build_system=cmake'
     mom5:
       require:
-      - '@git.fd4e09d8bf26da98cf011624890e136c6e23b705=access-om2'  # On branch 'dkhutch-nesi'
+      - '@git.240ceb1b633f917c05499b0eee02940625938e3e=access-om2'  # On branch 'dkhutch-nesi'
     libaccessom2:
       require:
-      - '@git.afd7abf4a00e29853f6ecf3134f172b11fad62d5=access-om2'  # On branch 'dkhutch-nesi'
+      - '@git.ae9244516f39cb15936819e901466ce11f806855=access-om2'  # On branch 'dkhutch-nesi'
     oasis3-mct:
       require:
       - '@git.2025.03.001'
@@ -41,14 +41,14 @@ spack:
       - '@5.0.8'
     access-fms:
       require:
-      - '@git.28f5cbadc41b823b882d3e411304f2e00265f14a=mom5'  # On branch 'dkhutch-nesi'
+      - '@git.95f4978b8d576b7d3e3b66362a3cfff83f7d3f73=mom5'  # On branch 'dkhutch-nesi'
       - 'cppflags="-DMAXFIELDMETHODS_=600"'
     access-generic-tracers:
       require:
-      - '@git.92a87ad44398809365591832f9a64811bf3c4a57=2026.01.000'  # On branch 'dkhutch-nesi'
+      - '@git.c7a14cb4466a51ea962ec28fec47cab2a4a3f5e4=2026.01.000'  # On branch 'dkhutch-nesi'
     access-mocsy:
       require:
-      - '@git.d4475dea14e9f6cf795f59f3f0cd200111ed8d0f=2025.07.002'  # On branch 'dkhutch-nesi'
+      - '@git.0e180aa968dcb257f318389bf089b59f9116f732=2025.07.002'  # On branch 'dkhutch-nesi'
     c:
       require:
       - 'intel-oneapi-compilers@2025.2.0'

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,15 +16,27 @@ spack:
       require:
       - '@git.5c2159bcfe13b8c597ddf049a80370c1fc8395cd=2026.01.000'  # On branch 'mavx2'
       - 'io_type=PIO build_system=cmake'
+      - 'cflags="-march=core-avx2"'
+      - 'cxxflags="-march=core-avx2"'
+      - 'fflags="-march=core-avx2"'
     mom5:
       require:
       - '@git.240ceb1b633f917c05499b0eee02940625938e3e=access-om2'  # On branch 'dkhutch-nesi'
+      - 'cflags="-march=core-avx2"'
+      - 'cxxflags="-march=core-avx2"'
+      - 'fflags="-march=core-avx2"'
     libaccessom2:
       require:
       - '@git.ae9244516f39cb15936819e901466ce11f806855=access-om2'  # On branch 'dkhutch-nesi'
+      - 'cflags="-march=core-avx2"'
+      - 'cxxflags="-march=core-avx2"'
+      - 'fflags="-march=core-avx2"'
     oasis3-mct:
       require:
       - '@git.2025.03.001'
+      - 'cflags="-march=core-avx2"'
+      - 'cxxflags="-march=core-avx2"'
+      - 'fflags="-march=core-avx2"'
 
     # Indirect dependencies
     netcdf-c:
@@ -43,12 +55,21 @@ spack:
       require:
       - '@git.95f4978b8d576b7d3e3b66362a3cfff83f7d3f73=mom5'  # On branch 'dkhutch-nesi'
       - 'cppflags="-DMAXFIELDMETHODS_=600"'
+      - 'cflags="-march=core-avx2"'
+      - 'cxxflags="-march=core-avx2"'
+      - 'fflags="-march=core-avx2"'
     access-generic-tracers:
       require:
       - '@git.c7a14cb4466a51ea962ec28fec47cab2a4a3f5e4=2026.01.000'  # On branch 'dkhutch-nesi'
+      - 'cflags="-march=core-avx2"'
+      - 'cxxflags="-march=core-avx2"'
+      - 'fflags="-march=core-avx2"'
     access-mocsy:
       require:
       - '@git.0e180aa968dcb257f318389bf089b59f9116f732=2025.07.002'  # On branch 'dkhutch-nesi'
+      - 'cflags="-march=core-avx2"'
+      - 'cxxflags="-march=core-avx2"'
+      - 'fflags="-march=core-avx2"'
     c:
       require:
       - 'intel-oneapi-compilers@2025.2.0'
@@ -61,11 +82,6 @@ spack:
     all:
       prefer:
       - 'target=x86_64_v4'
-      - 'cflags="-march=core-avx2"'
-      - 'cxxflags="-march=core-avx2"'
-      - 'fflags="-march=core-avx2"'
   view: true
   concretizer:
     unify: true
-    targets:
-      granularity: microarchitectures

--- a/spack.yaml
+++ b/spack.yaml
@@ -66,4 +66,3 @@ spack:
     unify: true
     targets:
       granularity: microarchitectures
-      host_compatible: false

--- a/spack.yaml
+++ b/spack.yaml
@@ -34,12 +34,15 @@ spack:
     netcdf-c:
       require:
       - '@4.9.2'
+      - 'target=x86_64_v4'
     netcdf-fortran:
       require:
       - '@4.6.1'
+      - 'target=x86_64_v4'
     parallelio:
       require:
       - '@2.6.8'
+      - 'target=x86_64_v4'
     openmpi:
       require:
       - '@5.0.8'
@@ -56,6 +59,26 @@ spack:
       require:
       - '@git.0e180aa968dcb257f318389bf089b59f9116f732=2025.07.002'  # On branch 'dkhutch-nesi'
       - 'target=x86_64_v3'
+    datetime-fortran:
+      require:
+      - '@1.7.0'
+      - 'target=x86_64_v4'
+    json-fortran:
+      require: 
+      - '@8.3.0'
+      - 'target=x86_64_v4'
+    hdf5:
+      require:
+      - '@1.14.6'
+      - 'target=x86_64_v4'
+    zlib-ng:
+      require:
+      - '@2.3.2'
+      - 'target=x86_64_v4'
+    pkgconf:
+      require:
+      - '@2.5.1'
+      - 'target=x86_64_v4'
     c:
       require:
       - 'intel-oneapi-compilers@2025.2.0'

--- a/spack.yaml
+++ b/spack.yaml
@@ -59,8 +59,11 @@ spack:
       require:
       - 'intel-oneapi-compilers@2025.2.0'
     all:
-      require:
-      - 'target=haswell'
+      prefer:
+      - 'target=x86_64_v4'
+      - 'cflags="-march=core-avx2"'
+      - 'cxxflags="-march=core-avx2"'
+      - 'fflags="-march=core-avx2"'
   view: true
   concretizer:
     unify: true

--- a/spack.yaml
+++ b/spack.yaml
@@ -60,7 +60,7 @@ spack:
       - 'intel-oneapi-compilers@2025.2.0'
     all:
       require:
-      - 'target=x86_64_v2'
+      - 'target=x86_64'
   view: true
   concretizer:
-    unify: false
+    unify: true

--- a/spack.yaml
+++ b/spack.yaml
@@ -70,4 +70,4 @@ spack:
       - 'target=x86_64_v4'
   view: true
   concretizer:
-    unify: true
+    unify: false

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,22 +16,15 @@ spack:
       require:
       - '@git.5c2159bcfe13b8c597ddf049a80370c1fc8395cd=2026.01.000'  # On branch 'mavx2'
       - 'io_type=PIO build_system=cmake'
-      - 'fflags="-mavx2 -mfma"'
-      - 'cflags="-mavx2 -mfma"'
     mom5:
       require:
       - '@git.240ceb1b633f917c05499b0eee02940625938e3e=access-om2'  # On branch 'dkhutch-nesi'
-      - 'fflags="-mavx2 -mfma"'
-      - 'cflags="-mavx2 -mfma"'
     libaccessom2:
       require:
       - '@git.ae9244516f39cb15936819e901466ce11f806855=access-om2'  # On branch 'dkhutch-nesi'
-      - 'fflags="-mavx2 -mfma"'
     oasis3-mct:
       require:
       - '@git.2025.03.001'
-      - 'fflags="-mavx2 -mfma"'
-      - 'cflags="-mavx2 -mfma"'
 
     # Indirect dependencies
     netcdf-c:
@@ -49,18 +42,13 @@ spack:
     access-fms:
       require:
       - '@git.95f4978b8d576b7d3e3b66362a3cfff83f7d3f73=mom5'  # On branch 'dkhutch-nesi'
-      - 'fflags="-mavx2 -mfma"'
-      - 'cflags="-mavx2 -mfma"'
-      - 'cppflags="-mavx2 -mfma -DMAXFIELDMETHODS_=600"'
+      - 'cppflags="-DMAXFIELDMETHODS_=600"'
     access-generic-tracers:
       require:
       - '@git.c7a14cb4466a51ea962ec28fec47cab2a4a3f5e4=2026.01.000'  # On branch 'dkhutch-nesi'
-      - 'fflags="-mavx2 -mfma"'
     access-mocsy:
       require:
       - '@git.0e180aa968dcb257f318389bf089b59f9116f732=2025.07.002'  # On branch 'dkhutch-nesi'
-      - 'fflags="-mavx2 -mfma"'
-      - 'cflags="-mavx2 -mfma"'
     c:
       require:
       - 'intel-oneapi-compilers@2025.2.0'
@@ -72,7 +60,7 @@ spack:
       - 'intel-oneapi-compilers@2025.2.0'
     all:
       prefer:
-      - 'target=x86_64_v4'
+      - 'target=x86_64_v3'
   view: true
   concretizer:
     unify: true

--- a/spack.yaml
+++ b/spack.yaml
@@ -34,15 +34,12 @@ spack:
     netcdf-c:
       require:
       - '@4.9.2'
-      - 'target=x86_64_v4'
     netcdf-fortran:
       require:
       - '@4.6.1'
-      - 'target=x86_64_v4'
     parallelio:
       require:
       - '@2.6.8'
-      - 'target=x86_64_v4'
     openmpi:
       require:
       - '@5.0.8'
@@ -59,26 +56,6 @@ spack:
       require:
       - '@git.0e180aa968dcb257f318389bf089b59f9116f732=2025.07.002'  # On branch 'dkhutch-nesi'
       - 'target=x86_64_v3'
-    datetime-fortran:
-      require:
-      - '@1.7.0'
-      - 'target=x86_64_v4'
-    json-fortran:
-      require: 
-      - '@8.3.0'
-      - 'target=x86_64_v4'
-    hdf5:
-      require:
-      - '@1.14.6'
-      - 'target=x86_64_v4'
-    zlib-ng:
-      require:
-      - '@2.3.2'
-      - 'target=x86_64_v4'
-    pkgconf:
-      require:
-      - '@2.5.1'
-      - 'target=x86_64_v4'
     c:
       require:
       - 'intel-oneapi-compilers@2025.2.0'
@@ -89,8 +66,8 @@ spack:
       require:
       - 'intel-oneapi-compilers@2025.2.0'
     all:
-      prefer:
+      require:
       - 'target=x86_64_v4'
   view: true
   concretizer:
-    unify: false
+    unify: true

--- a/spack.yaml
+++ b/spack.yaml
@@ -64,3 +64,6 @@ spack:
   view: true
   concretizer:
     unify: true
+    targets:
+      granularity: microarchitectures
+      host_compatible: false

--- a/spack.yaml
+++ b/spack.yaml
@@ -64,3 +64,5 @@ spack:
   view: true
   concretizer:
     unify: true
+    targets:
+        granularity: microarchitectures

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,15 +16,22 @@ spack:
       require:
       - '@git.5c2159bcfe13b8c597ddf049a80370c1fc8395cd=2026.01.000'  # On branch 'mavx2'
       - 'io_type=PIO build_system=cmake'
+      - 'fflags="-mavx2 -mfma"'
+      - 'cflags="-mavx2 -mfma"'
     mom5:
       require:
       - '@git.240ceb1b633f917c05499b0eee02940625938e3e=access-om2'  # On branch 'dkhutch-nesi'
+      - 'fflags="-mavx2 -mfma"'
+      - 'cflags="-mavx2 -mfma"'
     libaccessom2:
       require:
       - '@git.ae9244516f39cb15936819e901466ce11f806855=access-om2'  # On branch 'dkhutch-nesi'
+      - 'fflags="-mavx2 -mfma"'
     oasis3-mct:
       require:
       - '@git.2025.03.001'
+      - 'fflags="-mavx2 -mfma"'
+      - 'cflags="-mavx2 -mfma"'
 
     # Indirect dependencies
     netcdf-c:
@@ -42,13 +49,18 @@ spack:
     access-fms:
       require:
       - '@git.95f4978b8d576b7d3e3b66362a3cfff83f7d3f73=mom5'  # On branch 'dkhutch-nesi'
-      - 'cppflags="-DMAXFIELDMETHODS_=600"'
+      - 'fflags="-mavx2 -mfma"'
+      - 'cflags="-mavx2 -mfma"'
+      - 'cppflags="-mavx2 -mfma -DMAXFIELDMETHODS_=600"'
     access-generic-tracers:
       require:
       - '@git.c7a14cb4466a51ea962ec28fec47cab2a4a3f5e4=2026.01.000'  # On branch 'dkhutch-nesi'
+      - 'fflags="-mavx2 -mfma"'
     access-mocsy:
       require:
       - '@git.0e180aa968dcb257f318389bf089b59f9116f732=2025.07.002'  # On branch 'dkhutch-nesi'
+      - 'fflags="-mavx2 -mfma"'
+      - 'cflags="-mavx2 -mfma"'
     c:
       require:
       - 'intel-oneapi-compilers@2025.2.0'
@@ -60,9 +72,7 @@ spack:
       - 'intel-oneapi-compilers@2025.2.0'
     all:
       prefer:
-      - 'target=cascadelake'
+      - 'target=x86_64_v4'
   view: true
   concretizer:
     unify: true
-    targets:
-        granularity: microarchitectures

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,19 +16,15 @@ spack:
       require:
       - '@git.5c2159bcfe13b8c597ddf049a80370c1fc8395cd=2026.01.000'  # On branch 'mavx2'
       - 'io_type=PIO build_system=cmake'
-      - 'target=x86_64_v3'
     mom5:
       require:
       - '@git.240ceb1b633f917c05499b0eee02940625938e3e=access-om2'  # On branch 'dkhutch-nesi'
-      - 'target=x86_64_v3'
     libaccessom2:
       require:
       - '@git.ae9244516f39cb15936819e901466ce11f806855=access-om2'  # On branch 'dkhutch-nesi'
-      - 'target=x86_64_v3'
     oasis3-mct:
       require:
       - '@git.2025.03.001'
-      - 'target=x86_64_v3'
 
     # Indirect dependencies
     netcdf-c:
@@ -47,15 +43,12 @@ spack:
       require:
       - '@git.95f4978b8d576b7d3e3b66362a3cfff83f7d3f73=mom5'  # On branch 'dkhutch-nesi'
       - 'cppflags="-DMAXFIELDMETHODS_=600"'
-      - 'target=x86_64_v3'
     access-generic-tracers:
       require:
       - '@git.c7a14cb4466a51ea962ec28fec47cab2a4a3f5e4=2026.01.000'  # On branch 'dkhutch-nesi'
-      - 'target=x86_64_v3'
     access-mocsy:
       require:
       - '@git.0e180aa968dcb257f318389bf089b59f9116f732=2025.07.002'  # On branch 'dkhutch-nesi'
-      - 'target=x86_64_v3'
     c:
       require:
       - 'intel-oneapi-compilers@2025.2.0'
@@ -67,7 +60,7 @@ spack:
       - 'intel-oneapi-compilers@2025.2.0'
     all:
       require:
-      - 'target=x86_64_v4'
+      - 'target=x86_64_v2'
   view: true
   concretizer:
     unify: false

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,15 +16,19 @@ spack:
       require:
       - '@git.5c2159bcfe13b8c597ddf049a80370c1fc8395cd=2026.01.000'  # On branch 'mavx2'
       - 'io_type=PIO build_system=cmake'
+      - 'target=x86_64_v3'
     mom5:
       require:
       - '@git.240ceb1b633f917c05499b0eee02940625938e3e=access-om2'  # On branch 'dkhutch-nesi'
+      - 'target=x86_64_v3'
     libaccessom2:
       require:
       - '@git.ae9244516f39cb15936819e901466ce11f806855=access-om2'  # On branch 'dkhutch-nesi'
+      - 'target=x86_64_v3'
     oasis3-mct:
       require:
       - '@git.2025.03.001'
+      - 'target=x86_64_v3'
 
     # Indirect dependencies
     netcdf-c:
@@ -43,12 +47,15 @@ spack:
       require:
       - '@git.95f4978b8d576b7d3e3b66362a3cfff83f7d3f73=mom5'  # On branch 'dkhutch-nesi'
       - 'cppflags="-DMAXFIELDMETHODS_=600"'
+      - 'target=x86_64_v3'
     access-generic-tracers:
       require:
       - '@git.c7a14cb4466a51ea962ec28fec47cab2a4a3f5e4=2026.01.000'  # On branch 'dkhutch-nesi'
+      - 'target=x86_64_v3'
     access-mocsy:
       require:
       - '@git.0e180aa968dcb257f318389bf089b59f9116f732=2025.07.002'  # On branch 'dkhutch-nesi'
+      - 'target=x86_64_v3'
     c:
       require:
       - 'intel-oneapi-compilers@2025.2.0'
@@ -60,7 +67,7 @@ spack:
       - 'intel-oneapi-compilers@2025.2.0'
     all:
       prefer:
-      - 'target=x86_64_v3'
+      - 'target=x86_64_v4'
   view: true
   concretizer:
     unify: true

--- a/spack.yaml
+++ b/spack.yaml
@@ -93,4 +93,4 @@ spack:
       - 'target=x86_64_v4'
   view: true
   concretizer:
-    unify: true
+    unify: false


### PR DESCRIPTION
This PR is to test removing/replacing -xCORE-AVX2 across the ACCESS-OM2 stack

---
:rocket: The latest prerelease `access-om2/pr138-11` at e44855d3d776a3953881b9a43c4fe57764e4a6e6 is here: https://github.com/ACCESS-NRI/ACCESS-OM2/pull/138#issuecomment-3994824334 :rocket:







---
:rocket: The latest prerelease `access-om2/pr138-19` at 89234e25109e0d88bf8c3244a76c0484342379bf is here: https://github.com/ACCESS-NRI/ACCESS-OM2/pull/138#issuecomment-4000971768 :rocket:







