### PR TITLE
Repro testing of mom5 and libaccessom2 updates for GCC

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -18,10 +18,10 @@ spack:
       - 'io_type=PIO build_system=cmake'
     mom5:
       require:
-      - '@git.2025.08.000=access-om2'
+      - '@git.c4fa2450034e09239fa73a5db76724c18e37c887=access-om2'  # On branch 'gcc'
     libaccessom2:
       require:
-      - '@git.2025.05.001=access-om2'
+      - '@git.5d905fa470d6f0541dc27cfc0eca913e9bcb192d=access-om2'  # On branch 'gcc'
     oasis3-mct:
       require:
       - '@git.2025.03.001'


### PR DESCRIPTION
PR for repro testing with oneapi:
- https://github.com/ACCESS-NRI/MOM5/pull/76
- https://github.com/ACCESS-NRI/libaccessom2/pull/29

---
:rocket: The latest prerelease `access-om2/pr139-1` at 7c8c07078e40f3da10b9a8fa1efee5e10f59cba6 is here: https://github.com/ACCESS-NRI/ACCESS-OM2/pull/139#issuecomment-3963776898 :rocket:
