### PR TITLE
update-configs: Add configs to default profile

### DIFF
--- a/config/auto-configs-pr.json
+++ b/config/auto-configs-pr.json
@@ -9,6 +9,16 @@
           "checks": {
             "repro": true
           }
+        },
+        "dev-025deg_jra55_ryf": {
+          "checks": {
+            "repro": true
+          }
+        },
+        "dev-01deg_jra55_ryf": {
+          "checks": {
+            "repro": true
+          }
         }
       }
     }


### PR DESCRIPTION
This PR adds the `dev-025deg_jra55_ryf` and `dev-01deg_jra55_ryf` configs to the default profile for the `!update-configs` command.

In the past, we have had repro at one resolution, but not at another, so I think these are helpful to have.

---
:rocket: The latest prerelease `access-om2/pr141-1` at 6e600263c365e26ea1e611c75d06fb70a5d2bd8c is here: https://github.com/ACCESS-NRI/ACCESS-OM2/pull/141#issuecomment-3970829995 :rocket:
