### PR TITLE
Release 2026.02.001 (redo)

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "2026.02.003"
+  "access-spack-packages": "2026.02.004"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@ spack:
   definitions:
   # _name and _version are reserved definitions that inform deployments
   - _name: [access-om2]
-  - _version: [2026.02.000]
+  - _version: [2026.02.001]
   # add package specs to the `specs` list
   specs:
   - access-om2
@@ -18,10 +18,10 @@ spack:
       - 'io_type=PIO build_system=cmake'
     mom5:
       require:
-      - '@git.2025.08.000=access-om2'
+      - '@git.2026.02.000=access-om2'
     libaccessom2:
       require:
-      - '@git.2025.05.001=access-om2'
+      - '@git.2026.02.000=access-om2'
     oasis3-mct:
       require:
       - '@git.2025.03.001'
@@ -41,11 +41,11 @@ spack:
       - '@5.0.8'
     access-fms:
       require:
-      - '@git.mom5-2025.05.000=mom5'
+      - '@git.mom5-2025.08.000=mom5'
       - 'cppflags="-DMAXFIELDMETHODS_=600"'
     access-generic-tracers:
       require:
-      - '@2026.01.000'
+      - '@2026.02.000'
     access-mocsy:
       require:
       - '@2025.07.002'


### PR DESCRIPTION
Redo of #140

We cancelled the deployment because we thought we may want to make additional changes based on testing in https://github.com/ACCESS-NRI/ACCESS-OM2/pull/138. However, no additional changes are ready at this point.

---
:rocket: The latest prerelease `access-om2/pr142-5` at 8f4d605a95ad8448cb3eb69478dcfb420e0d7f3f is here: https://github.com/ACCESS-NRI/ACCESS-OM2/pull/142#issuecomment-3981612670 :rocket:
