### PR TITLE
Release ACCESS-OM2 2026.02.002

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "2026.02.004"
+  "access-spack-packages": "2026.03.002"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@ spack:
   definitions:
   # _name and _version are reserved definitions that inform deployments
   - _name: [access-om2]
-  - _version: [2026.02.001]
+  - _version: [2026.02.002]
   # add package specs to the `specs` list
   specs:
   - access-om2
@@ -45,7 +45,7 @@ spack:
       - 'cppflags="-DMAXFIELDMETHODS_=600"'
     access-generic-tracers:
       require:
-      - '@2026.02.000'
+      - '@2026.02.001'
     access-mocsy:
       require:
       - '@2025.07.002'


### PR DESCRIPTION
This release updates access-generic-tracers to 2026.02.001 to include a minor bug fix in WOMBATlite.

Justification for not incrementing the version month is:
- this only changes the access-generic-tracers version so non-BGC applications are identical
- the bug fix in WOMBATlite is quite minor

Closes #143 

---
:rocket: The latest prerelease `access-om2/pr144-1` at 9714d88464b748fe5216889be44561d6ac667006 is here: https://github.com/ACCESS-NRI/ACCESS-OM2/pull/144#issuecomment-4064089325 :rocket:
