### PR TITLE
Update to access-generic-tracers 2026.04.000

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "2026.03.002"
+  "access-spack-packages": "2026.04.001"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -45,7 +45,7 @@ spack:
       - 'cppflags="-DMAXFIELDMETHODS_=600"'
     access-generic-tracers:
       require:
-      - '@2026.02.001'
+      - '@2026.04.000'
     access-mocsy:
       require:
       - '@2025.07.002'


### PR DESCRIPTION
PR for prerelease using [access-generic-tracers 2026.04.000](https://github.com/ACCESS-NRI/GFDL-generic-tracers/releases/tag/2026.04.000)

---
:rocket: The latest prerelease `access-om2/pr145-1` at 52f372760bb104b3746650c358fb1574ab62bc39 is here: https://github.com/ACCESS-NRI/ACCESS-OM2/pull/145#issuecomment-4332995007 :rocket:
