### PR TITLE
Release ACCESS-OM2 2026.05.000

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "2026.03.002"
+  "access-spack-packages": "2026.05.001"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@ spack:
   definitions:
   # _name and _version are reserved definitions that inform deployments
   - _name: [access-om2]
-  - _version: [2026.02.002]
+  - _version: [2026.05.000]
   # add package specs to the `specs` list
   specs:
   - access-om2
@@ -45,7 +45,7 @@ spack:
       - 'cppflags="-DMAXFIELDMETHODS_=600"'
     access-generic-tracers:
       require:
-      - '@2026.02.001'
+      - '@2026.05.000'
     access-mocsy:
       require:
       - '@2025.07.002'


### PR DESCRIPTION
This release updates access-generic-tracers to 2026.05.000. This is a [major update](https://github.com/ACCESS-NRI/GFDL-generic-tracers/compare/2026.02.001...2026.05.000) to WOMBAT. All other package versions are unchanged.

Closes #147 

---
:rocket: The latest prerelease `access-om2/pr148-1` at 1e3408bbf1f684c9395792af87b930bc710b0c2a is here: https://github.com/ACCESS-NRI/ACCESS-OM2/pull/148#issuecomment-4494168275 :rocket:

