### PR TITLE
spack.yaml: use real versions

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "2026.05.001"
+  "access-spack-packages": "2026.08.000"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -18,13 +18,13 @@ spack:
       - 'io_type=PIO build_system=cmake'
     mom5:
       require:
-      - '@git.2026.02.000=access-om2'
+      - '@2026.02.000'
     libaccessom2:
       require:
-      - '@git.2026.02.000=access-om2'
+      - '@2026.02.000'
     oasis3-mct:
       require:
-      - '@git.2025.03.001'
+      - '@2025.03.001'
 
     # Indirect dependencies
     netcdf-c:
@@ -41,7 +41,7 @@ spack:
       - '@5.0.8'
     access-fms:
       require:
-      - '@git.mom5-2025.08.000=mom5'
+      - '@2025.08.000'
       - 'cppflags="-DMAXFIELDMETHODS_=600"'
     access-generic-tracers:
       require:


### PR DESCRIPTION
* Use a tag in config/versions.json before merging.

---
:rocket: The latest prerelease `access-om2/pr154-11` at b1287669298657ea93829a3590c1336c7e6dc0bb is here: https://github.com/ACCESS-NRI/ACCESS-OM2/pull/154#issuecomment-5199292989 :rocket:











