### PR TITLE
Test access-spack-packages branch `cleanup-before-esm1.6-release`

### DIFF
--- a/config/auto-configs-pr.json
+++ b/config/auto-configs-pr.json
@@ -5,17 +5,7 @@
     "default": {
       "configs_repo": "ACCESS-NRI/access-om2-configs",
       "configs": {
-        "dev-1deg_jra55_ryf": {
-          "checks": {
-            "repro": true
-          }
-        },
-        "dev-025deg_jra55_ryf": {
-          "checks": {
-            "repro": true
-          }
-        },
-        "dev-01deg_jra55_ryf": {
+        "dev-1deg_jra55_ryf+wombatlite": {
           "checks": {
             "repro": true
           }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "2026.05.001"
+  "access-spack-packages": "7c9a6296667f830ae5607410a4c2ffe3adba0651"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -18,13 +18,13 @@ spack:
       - 'io_type=PIO build_system=cmake'
     mom5:
       require:
-      - '@git.2026.02.000=access-om2'
+      - '@2026.02.000'
     libaccessom2:
       require:
-      - '@git.2026.02.000=access-om2'
+      - '@2026.02.000'
     oasis3-mct:
       require:
-      - '@git.2025.03.001'
+      - '@2025.03.001'
 
     # Indirect dependencies
     netcdf-c:
@@ -41,7 +41,7 @@ spack:
       - '@5.0.8'
     access-fms:
       require:
-      - '@git.mom5-2025.08.000=mom5'
+      - '@2025.08.000'
       - 'cppflags="-DMAXFIELDMETHODS_=600"'
     access-generic-tracers:
       require:


### PR DESCRIPTION
This PR is to test the proposed changes to `access-spack-packages` in [this PR](https://github.com/ACCESS-NRI/access-spack-packages/pull/443), which:

- removes support for ACCESS-ESM1.5
- removes makefile support from the mom5 SPR
- moves mom5, access_fms, libaccessom2 to numerical versioning

---
:rocket: The latest prerelease `access-om2/pr155-2` at c11ac0e57fa52391082bb811f5df486b6912d4f4 is here: https://github.com/ACCESS-NRI/ACCESS-OM2/pull/155#issuecomment-5127551147 :rocket:

