### PR TITLE
Prerelease for testing libaccessom2 `calendar_override`

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -26,7 +26,7 @@ spack:
       - '@2026.02.000'
     libaccessom2:
       require:
-      - '@2026.02.000'
+      - '@git.d698a9e6656c42e76672c11c8cf6b4f618334c74=2026.02.000'  # On branch 32-calendar-override
     oasis3-mct:
       require:
       - '@2025.03.001'


### PR DESCRIPTION
This PR is to create a prerelease for testing https://github.com/ACCESS-NRI/libaccessom2/pull/33

---
:rocket: The latest prerelease `access-om2/pr156-1` at c2a4e8eaab8693684081f39009b797efceec67a1 is here: https://github.com/ACCESS-NRI/ACCESS-OM2/pull/156#issuecomment-5275271574 :rocket:
