### PR TITLE
Release ACCESS-OM2 2026.08.000

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@ spack:
   definitions:
   # _name and _version are reserved definitions that inform deployments
   - _name: [access-om2]
-  - _version: [2026.05.000]
+  - _version: [2026.08.000]
   # _spack-version and _custom-scopes inform the branch of spack to use, and custom scopes if applicable, respectively
   - _spack-version: ["1.1"]
   # Release database provenance information - packages for inclusion into the database, and packages just for injection into the modules

--- a/spack.yaml
+++ b/spack.yaml
@@ -19,7 +19,7 @@ spack:
     # Direct dependencies
     cice5:
       require:
-      - '@2026.01.000'
+      - '@2026.07.000'
       - 'io_type=PIO build_system=cmake'
     mom5:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -46,7 +46,7 @@ spack:
       - '@5.0.8'
     access-fms:
       require:
-      - '@2025.08.000'
+      - '@2025.08.001'
       - 'cppflags="-DMAXFIELDMETHODS_=600"'
     access-generic-tracers:
       require:
@@ -72,5 +72,5 @@ spack:
   repos:
     access_spack_packages:
       git: https://github.com/ACCESS-NRI/access-spack-packages.git
-      tag: 2026.08.006
+      tag: 2026.08.007
       destination: $env/package-repos/access-spack-packages

--- a/spack.yaml
+++ b/spack.yaml
@@ -23,7 +23,7 @@ spack:
       - 'io_type=PIO build_system=cmake'
     mom5:
       require:
-      - '@2026.02.000'
+      - '@2026.02.001'
     libaccessom2:
       require:
       - '@2026.08.000'

--- a/spack.yaml
+++ b/spack.yaml
@@ -26,7 +26,7 @@ spack:
       - '@2026.02.000'
     libaccessom2:
       require:
-      - '@2026.02.000'
+      - '@2026.08.000'
     oasis3-mct:
       require:
       - '@2025.03.001'
@@ -72,5 +72,5 @@ spack:
   repos:
     access_spack_packages:
       git: https://github.com/ACCESS-NRI/access-spack-packages.git
-      tag: 2026.08.000
+      tag: 2026.08.006
       destination: $env/package-repos/access-spack-packages


### PR DESCRIPTION
Included in this release:
- [x] `libaccessom2` update to allow `calendar_override`
- [x] `CICE5` update to "fix a few diagnostics that no one uses" (quote @anton-seaice)
- [x] `MOM5` update to fix units in diagnostic temp diagnostic
- [x] `FMS` update to allow setting date prefix/separator in ocean diagnostic filenames

---
:rocket: The latest prerelease `access-om2/pr157-10` at 1f7625323dab99d0fd98b983f39e9a1552d21736 is here: https://github.com/ACCESS-NRI/ACCESS-OM2/pull/157#issuecomment-5310304806 :rocket:






