### PR TITLE
Update auto-configs-pr default profile

### DIFF
--- a/config/auto-configs-pr.json
+++ b/config/auto-configs-pr.json
@@ -5,17 +5,12 @@
     "default": {
       "configs_repo": "ACCESS-NRI/access-om2-configs",
       "configs": {
-        "dev-1deg_jra55_ryf": {
+        "dev-1deg_jra55_ryf+wombatlite": {
           "checks": {
             "repro": true
           }
         },
-        "dev-025deg_jra55_ryf": {
-          "checks": {
-            "repro": true
-          }
-        },
-        "dev-01deg_jra55_ryf": {
+        "dev-025deg_jra55_iaf": {
           "checks": {
             "repro": true
           }


### PR DESCRIPTION
Does what it says on the box. Justification for the configs included is similar to [here](https://github.com/ACCESS-NRI/access-om2-configs/pull/354), ie:

- covers ryf and iaf (at 025 deg where we've previously had unnoticed repro issues)
- covers wombatlite (at lowest res to reduce cost/time)