### PR TITLE
Build with the latest CICE5 with the runtime params feature

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -19,7 +19,7 @@ spack:
     # Direct dependencies
     cice5:
       require:
-      - '@2026.07.000'
+      - '@git.345d1fba9ab4b7c01aa556f310094c7831e931f3'
       - 'io_type=PIO build_system=cmake'
     mom5:
       require:


### PR DESCRIPTION
Deploying to test for bitwise repro for the OM2 configs

---
:rocket: The latest prerelease `access-om2/pr160-1` at 1836922c3c94eb52c6d388b319b833fa12fc57a4 is here: https://github.com/ACCESS-NRI/ACCESS-OM2/pull/160#issuecomment-5312582484 :rocket:

